### PR TITLE
added option for arguments in systemd worker and scheduler

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -20,6 +20,10 @@ airflow_services:
   - scheduler
   - worker
 
+# start systemD services with arguments
+airflow_worker_arguments: ""
+airflow_scheduler_arguments: "-n 5"
+
 # default main airflow configuration in yaml form
 default_airflow:
   core:

--- a/templates/etc/systemd/system/airflow-scheduler.service.j2
+++ b/templates/etc/systemd/system/airflow-scheduler.service.j2
@@ -10,7 +10,7 @@ Environment="AIRFLOW_HOME={{ airflow_install_directory }}"
 User={{ airflow_user }}
 Group={{ airflow_user }}
 Type=simple
-ExecStart=/usr/local/bin/airflow scheduler "{{ airflow_scheduler_arguments }}"
+ExecStart=/usr/local/bin/airflow scheduler {{ airflow_scheduler_arguments }}
 Restart=always
 RestartSec=5s
 

--- a/templates/etc/systemd/system/airflow-scheduler.service.j2
+++ b/templates/etc/systemd/system/airflow-scheduler.service.j2
@@ -10,7 +10,7 @@ Environment="AIRFLOW_HOME={{ airflow_install_directory }}"
 User={{ airflow_user }}
 Group={{ airflow_user }}
 Type=simple
-ExecStart=/usr/local/bin/airflow scheduler -n 5
+ExecStart=/usr/local/bin/airflow scheduler "{{ airflow_scheduler_arguments }}"
 Restart=always
 RestartSec=5s
 

--- a/templates/etc/systemd/system/airflow-worker.service.j2
+++ b/templates/etc/systemd/system/airflow-worker.service.j2
@@ -10,7 +10,7 @@ Environment="AIRFLOW_HOME={{ airflow_install_directory }}"
 User={{ airflow_user }}
 Group={{ airflow_user }}
 Type=simple
-ExecStart=/usr/local/bin/airflow worker "{{ airflow_worker_arguments }}"
+ExecStart=/usr/local/bin/airflow worker {{ airflow_worker_arguments }}
 Restart=on-failure
 RestartSec=10s
 

--- a/templates/etc/systemd/system/airflow-worker.service.j2
+++ b/templates/etc/systemd/system/airflow-worker.service.j2
@@ -10,7 +10,7 @@ Environment="AIRFLOW_HOME={{ airflow_install_directory }}"
 User={{ airflow_user }}
 Group={{ airflow_user }}
 Type=simple
-ExecStart=/usr/local/bin/airflow worker
+ExecStart=/usr/local/bin/airflow worker "{{ airflow_worker_arguments }}"
 Restart=on-failure
 RestartSec=10s
 


### PR DESCRIPTION
needed to be able to pass arguments to the systemD airflow worker in order to specify things like queues