### PR TITLE
moved logic from install-redhat to configure

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -7,3 +7,10 @@
     mode: 0644
     owner: "{{ airflow_user }}"
     group: "{{ airflow_user }}"
+
+- name: Symlink /usr/bin/airflow to /usr/local/bin/airflow
+  file:
+    state: link
+    src: /usr/bin/airflow
+    dest: /usr/local/bin/airflow
+  when: ansible_distribution == 'CentOS' or ansible_distribution == 'Red Hat Enterprise Linux'

--- a/tasks/install-redhat.yml
+++ b/tasks/install-redhat.yml
@@ -12,8 +12,3 @@
   easy_install:
     name: pip
 
-- name: Symlink /usr/bin/airflow to /usr/local/bin/airflow
-  file:
-    state: link
-    src: /usr/bin/airflow
-    dest: /usr/local/bin/airflow


### PR DESCRIPTION
there was a task in "install-redhat.yml" that was causing the play to break because airflow hasn't been installed yet. moved the task to "configuration.yml" and made it execute only when redhat